### PR TITLE
Fixed Travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ install:
   - sudo apt-get install -y build-essential
   - sudo apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
   - sudo apt-get install -y python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
-  - git clone https://github.com/Itseez/opencv.git
-  - cd opencv
+  - curl -sL https://github.com/Itseez/opencv/archive/3.3.0.zip > opencv.zip
+  - unzip opencv.zip
+  - cd opencv-3.3.0
   - mkdir build
   - cd build
   - cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D WITH_TBB=ON -D WITH_V4L=ON -D WITH_QT=ON -D WITH_OPENGL=ON ..


### PR DESCRIPTION
Unfortunately it took a while (and a lot of commits) to fix the travis build error. The reason was the OpenCV installation was installing the latest version OpenCV, which was different from the one installed on local machine. By setting the version as same as the local machine, the error was resolved. 